### PR TITLE
fs: add ioctl() file method

### DIFF
--- a/tests/custom/03_stdlib/40_proto
+++ b/tests/custom/03_stdlib/40_proto
@@ -38,6 +38,7 @@ When invoked with two arguments, returns the given value.
 Hello, World!
 [
 	{
+		"ioctl": "function ioctl(...) { [native code] }",
 		"lock": "function lock(...) { [native code] }",
 		"truncate": "function truncate(...) { [native code] }",
 		"isatty": "function isatty(...) { [native code] }",


### PR DESCRIPTION
implements ioctl() for a given file handle on Linux.